### PR TITLE
Uncaught PHP_CodeSniffer_Exception: Referenced sniff PEAR.Files.LineEndings does not exist

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -7,7 +7,11 @@
       <property name="applicationRoot" value="/application/"/>
     </properties>
   </rule>
-  <rule ref="PEAR.Files.LineEndings"/>
+  <rule ref="Generic.Files.LineEndings">
+    <properties>
+      <property name="eolChar" value="\n"/>
+    </properties>
+  </rule>
   <rule ref="Zend.Files.ClosingTag"/>
   <rule ref="Generic.PHP.DisallowShortOpenTag"/>
   <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>


### PR DESCRIPTION
PHP Fatal error:  Uncaught PHP_CodeSniffer_Exception: Referenced sniff PEAR.Files.LineEndings does not exist in /usr/share/php/PHP/CodeSniffhp on line 738
#0 /usr/share/php/PHP/CodeSniffer.php(738): PHP_CodeSniffer->_expandRulesetReference(Object(SimpleXMLElement))
#1 /usr/share/php/PHP/CodeSniffer.php(631): PHP_CodeSniffer->getSniffFiles('/usr/share/php/...', 'CodeIgniter')
#2 /usr/share/php/PHP/CodeSniffer.php(446): PHP_CodeSniffer->setTokenListeners('CodeIgniter', Array)
#3 /usr/share/php/PHP/CodeSniffer/CLI.php(542): PHP_CodeSniffer->process(Array, 'CodeIgniter', Array, false)
#4 /usr/bin/phpcs(38): PHP_CodeSniffer_CLI->process()
#5 {main}

  thrown in /usr/share/php/PHP/CodeSniffer.php on line 822
